### PR TITLE
Fixed a minor variable in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ fmt.Printf("Joystick Name: %s", js.Name())
 fmt.Printf("   Axis Count: %d", js.AxisCount())
 fmt.Printf(" Button Count: %d", js.ButtonCount())
 
-state, err := joystick.Read()
+state, err := js.Read()
 if err != nil {
   panic(err)
 }


### PR DESCRIPTION
The line in the code for Read() should be `js.Read()` instead of `joystick.Read()`